### PR TITLE
Add Access Levels with Tests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "165fc6d22394c1168ff76ab5d951245971ef07e5",
-        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-06-05-a"
+        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
+        "version" : "509.0.0"
       }
     }
   ],

--- a/Sources/SFSymbolsMacroImpl/SFSymbolsMacro.swift
+++ b/Sources/SFSymbolsMacroImpl/SFSymbolsMacro.swift
@@ -115,7 +115,7 @@ public struct SFSymbolMacro: MemberMacro {
                 .init(node: Syntax(declaration), message: SFSymbolDiagnostic.notAnEnum)
             ])
         }
-        guard let accessLevel = enumdeclaration.modifiers?.first(where: \.isNeededAccessLevelModifier)?.name.trimmed else {
+        guard let accessLevel = enumdeclaration.modifiers.first(where: \.isNeededAccessLevelModifier)?.name.trimmed else {
             return ""
         }
         return "\(accessLevel.text) "

--- a/Tests/SFSymbolsMacroTests/SFSymbolsMacroTests.swift
+++ b/Tests/SFSymbolsMacroTests/SFSymbolsMacroTests.swift
@@ -24,13 +24,16 @@ final class SFSymbolsMacroTests: XCTestCase {
             enum Symbols: String {
                 case globe
                 case circleFill = "circle.fill"
+
                 var image: Image {
                     Image(systemName: self.rawValue)
                 }
+
                 var name: String {
                     self.rawValue
                 }
-                #if canImport(UIKit)
+
+                #if canImport (UIKit)
                 func uiImage(configuration: UIImage.Configuration? = nil) -> UIImage {
                     UIImage(systemName: self.rawValue, withConfiguration: configuration)!
                 }
@@ -39,6 +42,7 @@ final class SFSymbolsMacroTests: XCTestCase {
                     return NSImage(systemSymbolName: self.rawValue, accessibilityDescription: accessibilityDescription)!
                 }
                 #endif
+
                 func callAsFunction() -> String {
                     return self.rawValue
                 }
@@ -63,13 +67,16 @@ final class SFSymbolsMacroTests: XCTestCase {
             public enum Symbols: String {
                 case globe
                 case circleFill = "circle.fill"
+
                 public var image: Image {
                     Image(systemName: self.rawValue)
                 }
+
                 public var name: String {
                     self.rawValue
                 }
-                #if canImport(UIKit)
+
+                #if canImport (UIKit)
                 public func uiImage(configuration: UIImage.Configuration? = nil) -> UIImage {
                     UIImage(systemName: self.rawValue, withConfiguration: configuration)!
                 }
@@ -78,6 +85,7 @@ final class SFSymbolsMacroTests: XCTestCase {
                     return NSImage(systemSymbolName: self.rawValue, accessibilityDescription: accessibilityDescription)!
                 }
                 #endif
+
                 public func callAsFunction() -> String {
                     return self.rawValue
                 }
@@ -102,13 +110,16 @@ final class SFSymbolsMacroTests: XCTestCase {
             internal enum Symbols: String {
                 case globe
                 case circleFill = "circle.fill"
+
                 internal var image: Image {
                     Image(systemName: self.rawValue)
                 }
+
                 internal var name: String {
                     self.rawValue
                 }
-                #if canImport(UIKit)
+
+                #if canImport (UIKit)
                 internal func uiImage(configuration: UIImage.Configuration? = nil) -> UIImage {
                     UIImage(systemName: self.rawValue, withConfiguration: configuration)!
                 }
@@ -117,6 +128,7 @@ final class SFSymbolsMacroTests: XCTestCase {
                     return NSImage(systemSymbolName: self.rawValue, accessibilityDescription: accessibilityDescription)!
                 }
                 #endif
+
                 internal func callAsFunction() -> String {
                     return self.rawValue
                 }
@@ -141,13 +153,16 @@ final class SFSymbolsMacroTests: XCTestCase {
             fileprivate enum Symbols: String {
                 case globe
                 case circleFill = "circle.fill"
+
                 fileprivate var image: Image {
                     Image(systemName: self.rawValue)
                 }
+
                 fileprivate var name: String {
                     self.rawValue
                 }
-                #if canImport(UIKit)
+
+                #if canImport (UIKit)
                 fileprivate func uiImage(configuration: UIImage.Configuration? = nil) -> UIImage {
                     UIImage(systemName: self.rawValue, withConfiguration: configuration)!
                 }
@@ -156,6 +171,7 @@ final class SFSymbolsMacroTests: XCTestCase {
                     return NSImage(systemSymbolName: self.rawValue, accessibilityDescription: accessibilityDescription)!
                 }
                 #endif
+
                 fileprivate func callAsFunction() -> String {
                     return self.rawValue
                 }
@@ -180,13 +196,16 @@ final class SFSymbolsMacroTests: XCTestCase {
             private enum Symbols: String {
                 case globe
                 case circleFill = "circle.fill"
+
                 private var image: Image {
                     Image(systemName: self.rawValue)
                 }
+
                 private var name: String {
                     self.rawValue
                 }
-                #if canImport(UIKit)
+
+                #if canImport (UIKit)
                 private func uiImage(configuration: UIImage.Configuration? = nil) -> UIImage {
                     UIImage(systemName: self.rawValue, withConfiguration: configuration)!
                 }
@@ -195,6 +214,7 @@ final class SFSymbolsMacroTests: XCTestCase {
                     return NSImage(systemSymbolName: self.rawValue, accessibilityDescription: accessibilityDescription)!
                 }
                 #endif
+
                 private func callAsFunction() -> String {
                     return self.rawValue
                 }

--- a/Tests/SFSymbolsMacroTests/SFSymbolsMacroTests.swift
+++ b/Tests/SFSymbolsMacroTests/SFSymbolsMacroTests.swift
@@ -48,6 +48,162 @@ final class SFSymbolsMacroTests: XCTestCase {
         )
     }
 
+    func testPublicSFSymbolMacro() {
+        assertMacroExpansion(
+            """
+            @SFSymbol
+            public enum Symbols: String {
+                case globe
+                case circleFill = "circle.fill"
+            }
+            """,
+            expandedSource:
+            """
+
+            public enum Symbols: String {
+                case globe
+                case circleFill = "circle.fill"
+                public var image: Image {
+                    Image(systemName: self.rawValue)
+                }
+                public var name: String {
+                    self.rawValue
+                }
+                #if canImport(UIKit)
+                public func uiImage(configuration: UIImage.Configuration? = nil) -> UIImage {
+                    UIImage(systemName: self.rawValue, withConfiguration: configuration)!
+                }
+                #else
+                public func nsImage(accessibilityDescription: String? = nil) -> NSImage {
+                    return NSImage(systemSymbolName: self.rawValue, accessibilityDescription: accessibilityDescription)!
+                }
+                #endif
+                public func callAsFunction() -> String {
+                    return self.rawValue
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func testInternalSFSymbolMacro() {
+        assertMacroExpansion(
+            """
+            @SFSymbol
+            internal enum Symbols: String {
+                case globe
+                case circleFill = "circle.fill"
+            }
+            """,
+            expandedSource:
+            """
+
+            internal enum Symbols: String {
+                case globe
+                case circleFill = "circle.fill"
+                internal var image: Image {
+                    Image(systemName: self.rawValue)
+                }
+                internal var name: String {
+                    self.rawValue
+                }
+                #if canImport(UIKit)
+                internal func uiImage(configuration: UIImage.Configuration? = nil) -> UIImage {
+                    UIImage(systemName: self.rawValue, withConfiguration: configuration)!
+                }
+                #else
+                internal func nsImage(accessibilityDescription: String? = nil) -> NSImage {
+                    return NSImage(systemSymbolName: self.rawValue, accessibilityDescription: accessibilityDescription)!
+                }
+                #endif
+                internal func callAsFunction() -> String {
+                    return self.rawValue
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func testFilePrivateSFSymbolMacro() {
+        assertMacroExpansion(
+            """
+            @SFSymbol
+            fileprivate enum Symbols: String {
+                case globe
+                case circleFill = "circle.fill"
+            }
+            """,
+            expandedSource:
+            """
+
+            fileprivate enum Symbols: String {
+                case globe
+                case circleFill = "circle.fill"
+                fileprivate var image: Image {
+                    Image(systemName: self.rawValue)
+                }
+                fileprivate var name: String {
+                    self.rawValue
+                }
+                #if canImport(UIKit)
+                fileprivate func uiImage(configuration: UIImage.Configuration? = nil) -> UIImage {
+                    UIImage(systemName: self.rawValue, withConfiguration: configuration)!
+                }
+                #else
+                fileprivate func nsImage(accessibilityDescription: String? = nil) -> NSImage {
+                    return NSImage(systemSymbolName: self.rawValue, accessibilityDescription: accessibilityDescription)!
+                }
+                #endif
+                fileprivate func callAsFunction() -> String {
+                    return self.rawValue
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func testPrivateSFSymbolMacro() {
+        assertMacroExpansion(
+            """
+            @SFSymbol
+            private enum Symbols: String {
+                case globe
+                case circleFill = "circle.fill"
+            }
+            """,
+            expandedSource:
+            """
+
+            private enum Symbols: String {
+                case globe
+                case circleFill = "circle.fill"
+                private var image: Image {
+                    Image(systemName: self.rawValue)
+                }
+                private var name: String {
+                    self.rawValue
+                }
+                #if canImport(UIKit)
+                private func uiImage(configuration: UIImage.Configuration? = nil) -> UIImage {
+                    UIImage(systemName: self.rawValue, withConfiguration: configuration)!
+                }
+                #else
+                private func nsImage(accessibilityDescription: String? = nil) -> NSImage {
+                    return NSImage(systemSymbolName: self.rawValue, accessibilityDescription: accessibilityDescription)!
+                }
+                #endif
+                private func callAsFunction() -> String {
+                    return self.rawValue
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
     func testInvalidSFSymbolError() {
         assertMacroExpansion(
             """
@@ -115,6 +271,28 @@ final class SFSymbolsMacroTests: XCTestCase {
     }
 
     func testInvalidType() {
+        assertMacroExpansion(
+            """
+            @SFSymbol
+            struct Symbols {
+                let xyz = "xyz"
+            }
+            """,
+            expandedSource:
+            """
+
+            struct Symbols {
+                let xyz = "xyz"
+            }
+            """,
+            diagnostics: [
+                .init(message: "Macro \"@SFSymbol\" can only be applied to enums.", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+    }
+
+    func testInvalidModifier() {
         assertMacroExpansion(
             """
             @SFSymbol


### PR DESCRIPTION
Hello I was attempting to use this macro inside of a local package and I was unable to access the properties from my project since they are set as `internal` by default. [Swift Access Control](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/accesscontrol)

I added a `accessLevel` for the following access types:
- public
- internal
- fileprivate
- private

Also added tests for all 4 new cases
